### PR TITLE
Fix typos, improve description

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,12 +42,12 @@ var rootCmd = &cobra.Command{
 	Use:   "abbreviate [string]",
 	Short: "Shorten your string using common abbreviations",
 	Long: `This tool will attempt to shorten the string provided using common abbreviations
-specified by language and 'set'. Word boundaries will detected using title case
-and non-letter.
+specified by language and 'set'. Word boundaries will be detected using title case
+and non-letters.
 
 Hosted on Github - https://github.com/dnnrly/abbreviate
 
-If you spot a bug then feel free to raise an issue of fix it and make a pull
+If you spot a bug, feel free to raise an issue or fix it and make a pull
 request. We're really interested to see more abbreviations added or corrected.`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if !optList && len(args) != 1 {


### PR DESCRIPTION
# Description

Fixes two typos in the 'long description' section of the CLI.

This is a very minor change. I hope it's helpful.