### PR TITLE
Fix: Add missing , preventing compiling

### DIFF
--- a/data/common-en-us.go
+++ b/data/common-en-us.go
@@ -735,7 +735,7 @@ var enUSCommon = map[string]string{
 	"identified":       "id",
 	"identify":         "id",
 	"image":            "img",
-	"images":           "img"
+	"images":           "img",
 	"inbound":          "in",
 	"implementation":   "impl",
 	"inch":             "in",


### PR DESCRIPTION
# Description

`make build` unable to complete due to a syntax error. This fixes it and `make build` works again. 