### PR TITLE
Add abbreviations for title case

### DIFF
--- a/cmd/title.go
+++ b/cmd/title.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"github.com/dnnrly/abbreviate/domain"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 // titleCmd represents the title command

--- a/cmd/title.go
+++ b/cmd/title.go
@@ -28,21 +28,9 @@ var titleCmd = &cobra.Command{
 	Long:  `Abbreviate a string and convert it to title case.`,
 	Args:  validateArgPresent,
 	Run: func(cmd *cobra.Command, args []string) {
-		abbr := domain.AsPascal(abbreviator, args[0], optMax, optFrmFront, optRemoveStopwords)
+		abbr := domain.ToTitle(abbreviator, args[0], optMax, optFrmFront, optRemoveStopwords)
 
-		if len(abbr) > 0 {
-			s := string(abbr[0])
-			for i := 1; i < len(abbr); i++ {
-				if string(abbr[i]) == strings.ToUpper(string(abbr[i])) {
-					s += " "
-				}
-				s += string(abbr[i])
-			}
-
-			fmt.Printf("%s", s)
-
-		}
-
+		fmt.Printf("%s", abbr)
 		if optNewline {
 			fmt.Printf("\n")
 		}

--- a/cmd/title.go
+++ b/cmd/title.go
@@ -1,0 +1,54 @@
+// Copyright © 2018 Pascal Dennerly
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/dnnrly/abbreviate/domain"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+// titleCmd represents the title command
+var titleCmd = &cobra.Command{
+	Use:   "title [string]",
+	Short: "Abbreviate a string and convert it to title case",
+	Long:  `Abbreviate a string and convert it to title case.`,
+	Args:  validateArgPresent,
+	Run: func(cmd *cobra.Command, args []string) {
+		abbr := domain.AsPascal(abbreviator, args[0], optMax, optFrmFront, optRemoveStopwords)
+
+		if len(abbr) > 0 {
+			s := string(abbr[0])
+			for i := 1; i < len(abbr); i++ {
+				if string(abbr[i]) == strings.ToUpper(string(abbr[i])) {
+					s += " "
+				}
+				s += string(abbr[i])
+			}
+
+			fmt.Printf("%s", s)
+
+		}
+
+		if optNewline {
+			fmt.Printf("\n")
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(titleCmd)
+}

--- a/domain/shorteners.go
+++ b/domain/shorteners.go
@@ -282,3 +282,24 @@ func shorten(sequences Sequences, max int, frmFront bool, shorten func(int)) Seq
 	}
 	return sequences
 }
+
+func ToTitle(abbr Abbreviator, original string, max int, frmFront bool, rmvStop bool) string {
+	if original == "" {
+		return ""
+	}
+
+	ab := AsPascal(abbr, original, max, frmFront, rmvStop)
+	s := ab
+
+	if len(ab) > 0 {
+		s = string(ab[0])
+		for i := 1; i < len(ab); i++ {
+			if string(ab[i]) == strings.ToUpper(string(ab[i])) {
+				s += " "
+			}
+			s += string(ab[i])
+		}
+	}
+
+	return s
+}

--- a/domain/shorteners_test.go
+++ b/domain/shorteners_test.go
@@ -293,3 +293,52 @@ ltd=limited`)
 		})
 	}
 }
+
+func TestToTitle(t *testing.T) {
+	matcher := NewMatcherFromString(`a=aaa
+b=bbb
+c=ccc
+d=ddd
+stg=strategy
+ltd=limited`)
+	tests := []struct {
+		name     string
+		original string
+		max      int
+		frmFront bool
+		rmvStop  bool
+		want     string
+	}{
+		{name: "Length longer than origin with '-'", original: "aaa-bbb-ccc", max: 99, want: "Aaa Bbb Ccc"},
+		{name: "Length is 0 with '-'", original: "aaa-bbb-ccc", max: 0, want: "A B C"},
+		{name: "Partial abbreviation with '-'", original: "aaa-bbb-ccc", max: 8, want: "Aaa Bbb C"},
+		{name: "Partial abbreviation with '-', start from the front", original: "aaa-bbb-ccc", max: 8, frmFront: true, want: "A Bbb Ccc"},
+		{name: "Length longer than origin with camel case", original: "AaaBbbCcc", max: 99, want: "Aaa Bbb Ccc"},
+		{name: "Length is 0 with camel case", original: "AaaBbbCcc", max: 0, want: "A B C"},
+		{name: "Length is 0 with camel case, matching case", original: "aaaBbbCcc", max: 0, want: "A B C"},
+		{name: "Partial abbreviation with camel case", original: "AaaBbbCcc", max: 8, want: "Aaa Bbb C"},
+		{name: "Partial abbreviation with camel case, start from the front", original: "AaaBbbCcc", max: 8, frmFront: true, want: "A Bbb Ccc"},
+		{name: "Doesn't match wrong casing", original: "AaaBBbCcc", max: 0, want: "A B Bb C"},
+		{name: "Mixed camel case and non word separators", original: "AaaBbb-ccc", max: 0, want: "A B C"},
+		{name: "Mixed camel case and non word separators with same borders", original: "Aaa-Bbb-Ccc", max: 0, want: "A B C"},
+		{name: "Real example, full short", original: "strategy-limited", max: 0, want: "Stg Ltd"},
+		{name: "Real example, shorter than total", original: "strategy-limited", max: 13, want: "Strategy Ltd"},
+		{name: "Real example, shorter than total, start from the front", original: "strategy-limited", max: 13, frmFront: true, want: "Stg Limited"},
+		{name: "Real example, max same as shorted", original: "strategy-limited", max: 12, want: "Strategy Ltd"},
+		{name: "Real example, max same as shorted", original: "strategy-limited", max: 12, frmFront: true, want: "Stg Limited"},
+		{name: "Real example, max on separator", original: "strategy-limited", max: 9, want: "Stg Ltd"},
+		{name: "Real example, max shorter than first word", original: "strategy-limited", max: 6, want: "Stg Ltd"},
+		{name: "Real example, no short", original: "strategy-limited", max: 99, want: "Strategy Limited"},
+		{name: "Real example, with numbers #1", original: "strategy-limited99", max: 15, want: "Strategy Ltd 9 9"},
+		{name: "Real example, with numbers #2", original: "strategy-limited-99", max: 15, want: "Strategy Ltd 9 9"},
+		{name: "Real example, with numbers #1, start from the front", original: "strategy-limited99", max: 15, frmFront: true, want: "Stg Limited 9 9"},
+		{name: "Real example, with numbers #2, start from the front", original: "strategy-limited-99", max: 15, frmFront: true, want: "Stg Limited 9 9"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToTitle(matcher, tt.original, tt.max, tt.frmFront, tt.rmvStop); got != tt.want {
+				t.Errorf("AsPascal('%s', %d) = '%v', want '%v'", tt.original, tt.max, got, tt.want)
+			}
+		})
+	}
+}

--- a/test/features/cli.feature
+++ b/test/features/cli.feature
@@ -41,6 +41,12 @@ Feature: Simple CLI commands
         When the app runs with parameters "kebab --max 15 strategy_limited"
         Then the app exits without error
         And the app output contains exactly "strategy-ltd"
+    
+    @Acceptance
+    Scenario: Title case
+        When the app runs with parameters "title --max 15 strategy_limited"
+        Then the app exits without error
+        And the app output contains exactly "Strategy Ltd"
 
     @Acceptance
     Scenario: Pascal case

--- a/test/features/cli.feature
+++ b/test/features/cli.feature
@@ -44,7 +44,7 @@ Feature: Simple CLI commands
     
     @Acceptance
     Scenario: Title case
-        When the app runs with parameters "title --max 15 strategy_limited"
+        When the app runs with parameters "title --max 14 strategy_limited"
         Then the app exits without error
         And the app output contains exactly "Strategy Ltd"
 

--- a/test/features/cli.feature
+++ b/test/features/cli.feature
@@ -46,7 +46,7 @@ Feature: Simple CLI commands
     Scenario: Title case
         When the app runs with parameters "title --max 14 strategy_limited"
         Then the app exits without error
-        And the app output contains exactly "Strategy Limited"
+        And the app output contains exactly "Strategy Ltd"
 
     @Acceptance
     Scenario: Pascal case

--- a/test/features/cli.feature
+++ b/test/features/cli.feature
@@ -46,7 +46,7 @@ Feature: Simple CLI commands
     Scenario: Title case
         When the app runs with parameters "title --max 14 strategy_limited"
         Then the app exits without error
-        And the app output contains exactly "Strategy Ltd"
+        And the app output contains exactly "Strategy Limited"
 
     @Acceptance
     Scenario: Pascal case


### PR DESCRIPTION
# Description

Adding support for title casing.
Running example:
```
➜  abbreviate git:(title-casing) ✗ ./abbreviate pascal prestrategy-limitedment
PrstgLtdmnt
➜  abbreviate git:(title-casing) ✗ ./abbreviate title prestrategy-limitedment   
Prstg Ltdmnt

```

Fixes #39 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Running existing tests
- [x] Created new tests

# Checklist:

- [x] My code has been linted (`make lint`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch to include the latest changes from `master`
